### PR TITLE
Fix Tracery links (HTTP, not HTTPS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Based on [a tweet thread](https://twitter.com/emilyhughes/status/975896813139124224).
 
-Uses [Kate Compton's](http://www.galaxykate.com/) magnificent [Tracery](https://tracery.io/) - specifically, the web template from [here](http://cmuems.com/2015b/tracery-twitterbots/).
+Uses [Kate Compton's](http://www.galaxykate.com/) magnificent [Tracery](http://tracery.io/) - specifically, the web template from [here](http://cmuems.com/2015b/tracery-twitterbots/).

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
 				<div id="details">
 					<p>Based on <a href="https://twitter.com/j_zimms/status/975898458153521157">a tweet thread</a>.</p>
-					<p>Uses <a href="http://www.galaxykate.com/">Kate's</a> magnificent <a href="https://tracery.io/">Tracery</a>
+					<p>Uses <a href="http://www.galaxykate.com/">Kate's</a> magnificent <a href="http://tracery.io/">Tracery</a>
 						 - specifically, the web template from <a href="http://cmuems.com/2015b/tracery-twitterbots/">here</a>.</p>
 					<p>Original generator <a href="https://yozlet.github.io/indiepub-generator/">built by yozlet</a>.</p>
 				


### PR DESCRIPTION
I just realised that my links to the Tracery homepage were broken. Merging this Pull Request should fix it cleanly. If you click the "Files changed" tab above, you'll see the diff (i.e. the total edits packaged in this PR, and how they differ from what your repo currently has).

Click the "Merge" button below to merge and close this PR. You can also add comments for a conversation about it, and all kinds of other whizzy GitHub features that you don't need to bother with yet.

Note if you're working on the repo locally on your machine (rather than editing through the GitHub web interface): After you've merged this PR, you'll need to do a `git pull` to fetch the changes in the GitHub repo down to your machine.